### PR TITLE
Add ARM64 build support and plugin.json fix for linux-arm64

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,28 @@
+FROM golang:1.22
+
+# Install build tools and Node.js 16.13.1 (same as original)
+RUN apt update && \
+    apt -y install build-essential curl git && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt -y install nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add non-root user (same as original)
+RUN addgroup --gid 1000 node && \
+    useradd --create-home --uid 1000 --gid node --shell /bin/sh node
+
+# Install golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+
+# Switch to user
+#USER node
+
+# Set working dir
+WORKDIR /plugin
+
+# Copy code and trust Git dir
+COPY . .
+RUN git config --global --add safe.directory /plugin
+
+# Build the plugin
+RUN make dist

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ endif
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/node_modules: $(wildcard webapp/package.json)
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && $(NPM) install
+	cd webapp && $(NPM) install --ignore-scripts
 	touch $@
 endif
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new Dockerfile for ARM64 architecture to support building and running the application on ARM-based systems.
  - Updated the Makefile to install NPM dependencies without running lifecycle scripts, improving installation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->